### PR TITLE
Fixing HIE time correction parsing-error that caused malformed pckts

### DIFF
--- a/packet-ieee802154.c
+++ b/packet-ieee802154.c
@@ -782,6 +782,7 @@ dissect_ieee802154_h_inf_elem(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tre
         default:
             if (!packet->keep_dissecting > 0) {  
                 condition = FALSE;
+            } else {
                 if(strcmp(val_to_str_const(packet->h_ie_id, ieee802154_h_information_elements_defined, "Unknown"), "Unknown") != 0) {
                     switch (packet->h_ie_id){
                         case IEEE802154_H_IE_TIME_CORRECTION:


### PR DESCRIPTION
This error lead to situations were non-HIE-termination IE were not parsed,
which then lead to malformed frames.

HIE-TERM-IE were correctly dissected if they were the only HIEs.
However, when there was e.g. a time correction HIE first (currently the only supported HIE), it was checked in the default branch of the switch statement, if the dissecting should stop (because the end of the HIE area was reached), which is apparently wrong for the time correction HIE.

This was easily fixable by introducing the `else`.

Signed-off-by: mstaflex jasper.buesch@gmail.com
